### PR TITLE
Fix bug: When no logs for job in jobstore, a

### DIFF
--- a/commons/types/src/main/java/dk/dbc/dataio/commons/types/JobSpecification.java
+++ b/commons/types/src/main/java/dk/dbc/dataio/commons/types/JobSpecification.java
@@ -38,7 +38,7 @@ public class JobSpecification implements Serializable {
     public static final String EMPTY_MAIL_FOR_NOTIFICATION_ABOUT_VERIFICATION = "";
     public static final String EMPTY_MAIL_FOR_NOTIFICATION_ABOUT_PROCESSING = "";
     public static final String EMPTY_RESULT_MAIL_INITIALS = "";
-    public static int JOB_EXPIRATION_AGE_IN_DAYS = 1460;
+    public static int JOB_EXPIRATION_AGE_IN_DAYS = 1825;
 
     public enum Type { TRANSIENT, PERSISTENT, TEST, ACCTEST, INFOMEDIA, PERIODIC, COMPACTED }
 

--- a/job-store-service/war/src/main/java/dk/dbc/dataio/jobstore/service/ejb/JobPurgeBean.java
+++ b/job-store-service/war/src/main/java/dk/dbc/dataio/jobstore/service/ejb/JobPurgeBean.java
@@ -141,7 +141,11 @@ public class JobPurgeBean {
         LOGGER.info("Compacting job {} of type {} that did complete at {}", jobInfoSnapshot.getJobId(),
                 jobInfoSnapshot.getSpecification().getType(), jobInfoSnapshot.getTimeOfCompletion());
         LOGGER.info("Purging log-store entries for job {}", jobInfoSnapshot.getJobId());
-        logStoreServiceConnectorBean.getConnector().deleteJobLogs(String.valueOf(jobInfoSnapshot.getJobId()));
+        try {
+            logStoreServiceConnectorBean.getConnector().deleteJobLogs(String.valueOf(jobInfoSnapshot.getJobId()));
+        } catch (LogStoreServiceConnectorUnexpectedStatusCodeException ignored) {
+
+        }
 
         Query query = entityManager.createQuery("select i from ItemEntity i where i.key.jobId = :jobid");
         query.setParameter("jobid", jobInfoSnapshot.getJobId());


### PR DESCRIPTION
LogstoreException would prevent removal of items and
chunks, as entire transaction is rolled back.