### PR TITLE
When constructing the output addi record then serialize recorddata as json

### DIFF
--- a/harvester/dmat/pom.xml
+++ b/harvester/dmat/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>dk.dbc</groupId>
       <artifactId>dmat-connector</artifactId>
-      <version>1.7-SNAPSHOT</version>
+      <version>1.8-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>dk.dbc</groupId>

--- a/harvester/dmat/src/main/java/dk/dbc/dataio/harvester/dmat/ExtendedAddiMetaData.java
+++ b/harvester/dmat/src/main/java/dk/dbc/dataio/harvester/dmat/ExtendedAddiMetaData.java
@@ -53,8 +53,8 @@ public class ExtendedAddiMetaData extends AddiMetaData {
     @Override
     public String toString() {
         return "AddiMetaDataWithRecord{" +
-                "dMatRecord=" + dmatRecord +
-                "dMatUrl=" + dmatUrl +
+                "dmatRecord=" + dmatRecord +
+                ", dmatUrl=" + dmatUrl +
                 "} " + super.toString();
     }
 }

--- a/harvester/dmat/src/main/java/dk/dbc/dataio/harvester/dmat/HarvestOperation.java
+++ b/harvester/dmat/src/main/java/dk/dbc/dataio/harvester/dmat/HarvestOperation.java
@@ -3,6 +3,8 @@ package dk.dbc.dataio.harvester.dmat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import dk.dbc.commons.addi.AddiRecord;
 import dk.dbc.commons.jsonb.JSONBException;
@@ -54,6 +56,11 @@ public class HarvestOperation {
     private final RecordServiceConnector recordServiceConnector;
     private final String dmatDownloadUrl;
 
+    public abstract class RecordDataMixIn {
+        @JsonSerialize(using = RecordDataSerializer.class)
+        public String recordData;
+    }
+
     public HarvestOperation(DMatHarvesterConfig config,
                             BinaryFileStore binaryFileStore,
                             FileStoreServiceConnector fileStoreServiceConnector,
@@ -74,6 +81,10 @@ public class HarvestOperation {
         objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        SimpleModule simpleModule = new SimpleModule();
+        simpleModule.setMixInAnnotation(DMatRecord.class, RecordDataMixIn.class);
+        objectMapper.registerModule(simpleModule);
     }
 
     public int execute() throws HarvesterException {

--- a/harvester/dmat/src/main/java/dk/dbc/dataio/harvester/dmat/RecordDataSerializer.java
+++ b/harvester/dmat/src/main/java/dk/dbc/dataio/harvester/dmat/RecordDataSerializer.java
@@ -15,7 +15,7 @@ public class RecordDataSerializer extends JsonSerializer<String> {
         try {
             jsonGenerator.writeObject(RecordData.fromRaw(recordData));
         } catch (JSONBException e) {
-            // No output, fail silently and let the flow script fail
+            throw new IOException(String.format("Unable to serialize object %s", recordData));
         }
     }
 }

--- a/harvester/dmat/src/main/java/dk/dbc/dataio/harvester/dmat/RecordDataSerializer.java
+++ b/harvester/dmat/src/main/java/dk/dbc/dataio/harvester/dmat/RecordDataSerializer.java
@@ -1,0 +1,21 @@
+package dk.dbc.dataio.harvester.dmat;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import dk.dbc.commons.jsonb.JSONBException;
+import dk.dbc.dmat.service.dto.RecordData;
+
+import java.io.IOException;
+
+public class RecordDataSerializer extends JsonSerializer<String> {
+
+    @Override
+    public void serialize(String recordData, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        try {
+            jsonGenerator.writeObject(RecordData.fromRaw(recordData));
+        } catch (JSONBException e) {
+            // No output, fail silently and let the flow script fail
+        }
+    }
+}

--- a/harvester/dmat/src/main/java/dk/dbc/dataio/harvester/dmat/RecordFetcher.java
+++ b/harvester/dmat/src/main/java/dk/dbc/dataio/harvester/dmat/RecordFetcher.java
@@ -32,15 +32,21 @@ public class RecordFetcher {
             return collection.asBytes();
         } else {
             LOGGER.info("No attached record for updateCode {} and selection {}", dMatRecord.getUpdateCode(), dMatRecord.getSelection());
-            return new byte[0];
+            return collection.emptyCollection();
         }
     }
 
     private static String getAttachedRecordId(DMatRecord dMatRecord) throws HarvesterException {
 
-        // updateCode NEW and AUTO with selection CREATE and CLONE => matched record
+        // updateCode NEW and AUTO with selection CREATE => no record
         if( Arrays.asList(UpdateCode.NEW, UpdateCode.AUTO).contains(dMatRecord.getUpdateCode() )
-                && Arrays.asList(Selection.CREATE, Selection.CLONE).contains(dMatRecord.getSelection())) {
+                && dMatRecord.getSelection() == Selection.CREATE ) {
+            return null;
+        }
+
+        // updateCode NEW and AUTO with selection CLONE => matched record
+        if( Arrays.asList(UpdateCode.NEW, UpdateCode.AUTO).contains(dMatRecord.getUpdateCode() )
+                && dMatRecord.getSelection() == Selection.CLONE ) {
             return dMatRecord.getMatch();
         }
 

--- a/harvester/dmat/src/test/java/dk/dbc/dataio/harvester/dmat/HarvestOperationTest.java
+++ b/harvester/dmat/src/test/java/dk/dbc/dataio/harvester/dmat/HarvestOperationTest.java
@@ -2,6 +2,9 @@ package dk.dbc.dataio.harvester.dmat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import dk.dbc.commons.addi.AddiReader;
 import dk.dbc.commons.addi.AddiRecord;
@@ -65,6 +68,7 @@ public class HarvestOperationTest {
     private HarvestOperation harvestOperation;
     private final DMatServiceConnector dmatServiceConnector = mock(DMatServiceConnector.class);
     private final RecordServiceConnector recordServiceConnector = mock(RecordServiceConnector.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HarvestOperationTest.class);
 
     @TempDir Path tempDir;
 
@@ -131,13 +135,10 @@ public class HarvestOperationTest {
         final AddiReader addiReader = new AddiReader(new ByteArrayInputStream(dataFile));
         if (addiReader.hasNext()) {
             final AddiRecord addiRecord = addiReader.next();
-
-            ObjectMapper objectMapper = new ObjectMapper();
-            objectMapper.registerModule(new JavaTimeModule());
-            objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-
-            ExtendedAddiMetaData meta = objectMapper.reader().readValue(addiRecord.getMetaData(), ExtendedAddiMetaData.class);
-            assertThat("dmat url", meta.getDmatUrl().equals("http://some.dmat.service/api/v1/records/1/download"));
+            String meta = new String(addiRecord.getMetaData());
+            assertThat("dmat url", meta.contains("\"dmatUrl\":\"http://some.dmat.service/api/v1/records/1/download\""));
+        } else {
+            throw new AssertionError("Expecting addi record");
         }
     }
 

--- a/harvester/dmat/src/test/java/dk/dbc/dataio/harvester/dmat/HarvestOperationTest.java
+++ b/harvester/dmat/src/test/java/dk/dbc/dataio/harvester/dmat/HarvestOperationTest.java
@@ -1,11 +1,5 @@
 package dk.dbc.dataio.harvester.dmat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import dk.dbc.commons.addi.AddiReader;
 import dk.dbc.commons.addi.AddiRecord;
 import dk.dbc.commons.jsonb.JSONBException;
@@ -140,6 +134,8 @@ public class HarvestOperationTest {
         } else {
             throw new AssertionError("Expecting addi record");
         }
+
+
     }
 
     @Test
@@ -189,7 +185,7 @@ public class HarvestOperationTest {
         when(recordServiceConnector.getRecordContent(191919, MATCH_FAUST, fetchParameters()))
                 .thenThrow(new RecordServiceConnectorException("No content"));
 
-        assertThrowsWithMessage(harvestOperation, 1, UpdateCode.NEW, Selection.CREATE, "Caught RecordServiceConnectorException");
+        assertThrowsWithMessage(harvestOperation, 1, UpdateCode.NEW, Selection.CLONE, "Caught RecordServiceConnectorException");
     }
 
     @Test
@@ -211,7 +207,8 @@ public class HarvestOperationTest {
         assertThat("Number of cases harvested", casesHarvested, is(1));
 
         verify(dmatServiceConnector).updateRecordStatus(1, Status.EXPORTED);
-        verify(recordServiceConnector, times(1)).getRecordContent(191919, MATCH_FAUST, fetchParameters());
+        verify(recordServiceConnector, times(0)).getRecordContent(any(Integer.class),
+                any(String.class), any(RecordServiceConnector.Params.class));
         verify(jobStoreServiceConnector).addJob(any(JobInputStream.class));
         verify(flowStoreServiceConnector).updateHarvesterConfig(any(DMatHarvesterConfig.class));
     }
@@ -259,7 +256,8 @@ public class HarvestOperationTest {
         assertThat("Number of cases harvested", casesHarvested, is(1));
 
         verify(dmatServiceConnector).updateRecordStatus(1, Status.EXPORTED);
-        verify(recordServiceConnector, times(1)).getRecordContent(191919, MATCH_FAUST, fetchParameters());
+        verify(recordServiceConnector, times(0)).getRecordContent(any(Integer.class),
+                any(String.class), any(RecordServiceConnector.Params.class));
         verify(jobStoreServiceConnector).addJob(any(JobInputStream.class));
         verify(flowStoreServiceConnector).updateHarvesterConfig(any(DMatHarvesterConfig.class));
     }

--- a/harvester/types/src/main/java/dk/dbc/dataio/harvester/types/MarcExchangeCollection.java
+++ b/harvester/types/src/main/java/dk/dbc/dataio/harvester/types/MarcExchangeCollection.java
@@ -1,24 +1,3 @@
-/*
- * DataIO - Data IO
- * Copyright (C) 2015 Dansk Bibliotekscenter a/s, Tempovej 7-11, DK-2750 Ballerup,
- * Denmark. CVR: 15149043
- *
- * This file is part of DataIO.
- *
- * DataIO is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * DataIO is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with DataIO.  If not, see <http://www.gnu.org/licenses/>.
- */
-
 package dk.dbc.dataio.harvester.types;
 
 import dk.dbc.marc.binding.MarcRecord;
@@ -31,6 +10,7 @@ import java.io.ByteArrayInputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 
 /**
  * This class represents a MARC Exchange Collection as a harvester XML record.
@@ -55,6 +35,13 @@ public class MarcExchangeCollection implements HarvesterXmlRecord {
             throw new HarvesterInvalidRecordException("Empty marcXchange collection");
         }
         return new MarcXchangeV1Writer().writeCollection(records, charset);
+    }
+
+    /**
+     * @return an empty collection, only containing the outer wrapper elements for the collection
+     */
+    public byte[] emptyCollection() {
+        return new MarcXchangeV1Writer().writeCollection(Collections.emptyList(), charset);
     }
 
     /**


### PR DESCRIPTION
since this is needed by the flowscripts.

The recordData property is kept as a string in the DMatRecord object, so we need
to add a custom serializer