### PR TITLE
Add initial handling of exports with updatecode PUBLISHER

### DIFF
--- a/gui/src/main/java/dk/dbc/dataio/gui/client/pages/harvester/dmat/modify/Presenter.java
+++ b/gui/src/main/java/dk/dbc/dataio/gui/client/pages/harvester/dmat/modify/Presenter.java
@@ -7,6 +7,7 @@ public interface Presenter extends GenericPresenter {
     void scheduleChanged(String schedule);
     void descriptionChanged(String description);
     void destinationChanged(String destination);
+    void publizonChanged(String publizon);
     void formatChanged(String format);
     void enabledChanged(Boolean value);
     void keyPressed();

--- a/gui/src/main/java/dk/dbc/dataio/gui/client/pages/harvester/dmat/modify/PresenterImpl.java
+++ b/gui/src/main/java/dk/dbc/dataio/gui/client/pages/harvester/dmat/modify/PresenterImpl.java
@@ -64,6 +64,13 @@ public abstract class PresenterImpl extends AbstractActivity implements Presente
     }
 
     @Override
+    public void publizonChanged(String publizon) {
+        if (config != null) {
+            config.getContent().withPublizon(publizon);
+        }
+    }
+
+    @Override
     public void formatChanged(String format) {
         if (config != null) {
             config.getContent().withFormat(format);
@@ -117,6 +124,7 @@ public abstract class PresenterImpl extends AbstractActivity implements Presente
         view.schedule.setEnabled(true);
         view.description.setEnabled(true);
         view.destination.setEnabled(true);
+        view.publizon.setEnabled(true);
         view.format.setEnabled(true);
         view.enabled.setEnabled(true);
     }
@@ -128,6 +136,7 @@ public abstract class PresenterImpl extends AbstractActivity implements Presente
         view.schedule.setText(configContent.getSchedule());
         view.description.setText(configContent.getDescription());
         view.destination.setText(configContent.getDestination());
+        view.publizon.setText(configContent.getPublizon());
         view.format.setText(configContent.getFormat());
         view.enabled.setValue(configContent.isEnabled());
         view.status.setText("");
@@ -140,6 +149,7 @@ public abstract class PresenterImpl extends AbstractActivity implements Presente
                 || isUndefined(config.getContent().getSchedule())
                 || isUndefined(config.getContent().getDescription())
                 || isUndefined(config.getContent().getDestination())
+                || isUndefined(config.getContent().getPublizon())
                 || isUndefined(config.getContent().getFormat());
     }
 

--- a/gui/src/main/java/dk/dbc/dataio/gui/client/pages/harvester/dmat/modify/Texts.java
+++ b/gui/src/main/java/dk/dbc/dataio/gui/client/pages/harvester/dmat/modify/Texts.java
@@ -17,6 +17,9 @@ public interface Texts extends com.google.gwt.i18n.client.Constants {
     String prompt_Destination();
 
     @DefaultStringValue(MainConstants.TRANSLATED_TEXT_IS_MISSING)
+    String prompt_Publizon();
+
+    @DefaultStringValue(MainConstants.TRANSLATED_TEXT_IS_MISSING)
     String prompt_Format();
 
     @DefaultStringValue(MainConstants.TRANSLATED_TEXT_IS_MISSING)

--- a/gui/src/main/java/dk/dbc/dataio/gui/client/pages/harvester/dmat/modify/Texts_dk.properties
+++ b/gui/src/main/java/dk/dbc/dataio/gui/client/pages/harvester/dmat/modify/Texts_dk.properties
@@ -2,7 +2,8 @@
 prompt_Name = Navn*
 prompt_Schedule = Hentningsfrekvens*
 prompt_Description = Beskrivelse*
-prompt_Destination = Destination*
+prompt_Destination = Destination, RR poster*
+prompt_Publizon = Destination, forlagsomtaler*
 prompt_Format = Format*
 prompt_Enabled = Enabled
 

--- a/gui/src/main/java/dk/dbc/dataio/gui/client/pages/harvester/dmat/modify/View.java
+++ b/gui/src/main/java/dk/dbc/dataio/gui/client/pages/harvester/dmat/modify/View.java
@@ -32,6 +32,7 @@ public class View extends ContentPanel<Presenter> implements IsWidget {
     @UiField PromptedTextBox schedule;
     @UiField PromptedTextArea description;
     @UiField PromptedTextBox destination;
+    @UiField PromptedTextBox publizon;
     @UiField PromptedTextBox format;
     @UiField PromptedCheckBox enabled;
 
@@ -63,6 +64,13 @@ public class View extends ContentPanel<Presenter> implements IsWidget {
     @UiHandler("destination")
     void destinationChanged(ValueChangeEvent<String> event) {
         presenter.destinationChanged(destination.getText());
+        presenter.keyPressed();
+    }
+
+    @SuppressWarnings("unused")
+    @UiHandler("publizon")
+    void publizonChanged(ValueChangeEvent<String> event) {
+        presenter.publizonChanged(publizon.getText());
         presenter.keyPressed();
     }
 

--- a/gui/src/main/java/dk/dbc/dataio/gui/client/pages/harvester/dmat/modify/View.ui.xml
+++ b/gui/src/main/java/dk/dbc/dataio/gui/client/pages/harvester/dmat/modify/View.ui.xml
@@ -10,6 +10,7 @@
         <li><prompted:PromptedTextBox ui:field="schedule" guiId="harvesterschedulepanel" prompt="{txt.prompt_Schedule}"/></li>
         <li><prompted:PromptedTextArea ui:field="description" guiId="harvesterdescriptionpanel" prompt="{txt.prompt_Description}" maxLength="160"/></li>
         <li><prompted:PromptedTextBox ui:field="destination" guiId="harvesterdestinationpanel" prompt="{txt.prompt_Destination}" maxLength="160"/></li>
+        <li><prompted:PromptedTextBox ui:field="publizon" guiId="harvesterpublizonpanel" prompt="{txt.prompt_Publizon}" maxLength="160"/></li>
         <li><prompted:PromptedTextBox ui:field="format" guiId="harvesterformatpanel" prompt="{txt.prompt_Format}"/></li>
         <li><prompted:PromptedCheckBox ui:field="enabled" guiId="enabled" prompt="{txt.prompt_Enabled}"/></li>
         <li>

--- a/harvester/dmat/pom.xml
+++ b/harvester/dmat/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>dk.dbc</groupId>
       <artifactId>dmat-connector</artifactId>
-      <version>1.8-SNAPSHOT</version>
+      <version>1.9-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>dk.dbc</groupId>

--- a/harvester/dmat/pom.xml
+++ b/harvester/dmat/pom.xml
@@ -137,6 +137,11 @@
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
     </dependency>
+    <dependency>
+      <groupId>dk.dbc</groupId>
+      <artifactId>tickle-repo-api</artifactId>
+      <version>1.1-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/harvester/dmat/src/main/java/dk/dbc/dataio/harvester/dmat/HarvestOperation.java
+++ b/harvester/dmat/src/main/java/dk/dbc/dataio/harvester/dmat/HarvestOperation.java
@@ -290,7 +290,8 @@ public class HarvestOperation {
         String metaData = objectMapper
                 .writerWithView(RecordView.Export.class).writeValueAsString(addiMetaData);
 
-        // Fetch record to use for cloning or to update. Wrap in a collection since this is required by DAM
+        // Fetch attached record. MarcXchange records is wrapped in a collection since this is required by DAM,
+        // even though there is ever only one record. Publizon records from tickle-repo is attached as is
         byte[] content = dmatRecord.getUpdateCode() == UpdateCode.PUBLISHER
                 ? TickleFetcher.getOnixProductFor(dmatRecord)
                 : RecordFetcher.getRecordCollectionFor(recordServiceConnector, dmatRecord);

--- a/harvester/dmat/src/main/java/dk/dbc/dataio/harvester/dmat/HarvestOperation.java
+++ b/harvester/dmat/src/main/java/dk/dbc/dataio/harvester/dmat/HarvestOperation.java
@@ -99,12 +99,18 @@ public class HarvestOperation {
 
     public int execute() throws HarvesterException {
         final StopWatch stopwatch = new StopWatch();
-        final Map<Integer, Status> statusAfterExport = new HashMap<>();
+        final Map<Integer, Status> statusAfterExportRr = new HashMap<>();
+        final Map<Integer, Status> statusAfterExportPublisher = new HashMap<>();
         int recordsHarvested = 0;
 
-        try (JobBuilder jobBuilder = new JobBuilder(
+        try {
+            JobBuilder rrJobBuilder = new JobBuilder(
                 binaryFileStore, fileStoreServiceConnector, jobStoreServiceConnector,
-                JobSpecificationTemplate.create(config))) {
+                JobSpecificationTemplate.create(config, JobSpecificationTemplate.JobSpecificationType.RR));
+            JobBuilder publisherJobBuilder = new JobBuilder(
+                    binaryFileStore, fileStoreServiceConnector, jobStoreServiceConnector,
+                    JobSpecificationTemplate.create(config, JobSpecificationTemplate.JobSpecificationType.PUBLISHER));
+
             final ResultSet dmatRecords = new ResultSet(dmatServiceConnector);
             for (DMatRecord dmatRecord : dmatRecords) {
                 LOGGER.info("Fetched dmat record {}", dmatRecord.getId());
@@ -114,24 +120,36 @@ public class HarvestOperation {
                 final ExtendedAddiMetaData addiMetaData = createAddiMetaData(dmatRecords.getCreationTime(), dmatRecord);
                 try {
                     DBCTrackedLogContext.setTrackingId(addiMetaData.trackingId());
-                    statusAfterExport.put(dmatRecord.getId(), Status.EXPORTED);
                     final AddiRecord addiRecord = createAddiRecord(recordServiceConnector, addiMetaData, dmatRecord);
-                    jobBuilder.addRecord(addiRecord);
+                    if( dmatRecord.getUpdateCode() == UpdateCode.PUBLISHER ) {
+                        publisherJobBuilder.addRecord(addiRecord);
+                        statusAfterExportPublisher.put(dmatRecord.getId(), Status.EXPORTED);
+                    } else {
+                        rrJobBuilder.addRecord(addiRecord);
+                        statusAfterExportRr.put(dmatRecord.getId(), Status.EXPORTED);
+                    }
+
                 } finally {
                     DBCTrackedLogContext.remove();
                 }
             }
 
-            jobBuilder.build();
 
-            // After the job has been successfully build, update the status of the
+            // After the job for RR records has been successfully build, update the status of the
             // harvested dmat records to ensure that no record is marked as exported
             // if job creation fails
-            statusAfterExport.forEach(this::updateStatus);
+            rrJobBuilder.build();
+            statusAfterExportRr.forEach(this::updateStatus);
+
+            // After the job for publisher records has been successfully build, update the status of the
+            // harvested dmat records to ensure that no record is marked as exported
+            // if job creation fails
+            publisherJobBuilder.build();
+            statusAfterExportPublisher.forEach(this::updateStatus);
 
             updateConfig(config);
 
-            recordsHarvested = jobBuilder.getRecordsAdded();
+            recordsHarvested = publisherJobBuilder.getRecordsAdded() + rrJobBuilder.getRecordsAdded();
             return recordsHarvested;
         } catch (DMatServiceConnectorException e) {
             LOGGER.error("Caught DMatServiceConnectorException: {}", e.getMessage());
@@ -229,6 +247,11 @@ public class HarvestOperation {
                     dmatRecord.getRecordId());
             return;
         }
+        if(dmatRecord.getUpdateCode() == UpdateCode.PUBLISHER) {
+            LOGGER.info("Received DMatRecord {} with faust {} for PUBLISHER:*", dmatRecord.getId(),
+                    dmatRecord.getRecordId());
+            return;
+        }
 
         // Remaining combinations is an error
         LOGGER.error("Received DMatRecord {} with unknown combination of updateCode {} and selection {}", dmatRecord.getId(),
@@ -241,7 +264,10 @@ public class HarvestOperation {
         ExtendedAddiMetaData metaData = ((ExtendedAddiMetaData) new ExtendedAddiMetaData()
                 .withTrackingId(String.join(".", "dmat", config.getLogId(),
                         String.valueOf(dmatRecord.getId())))
-                .withSubmitterNumber(JobSpecificationTemplate.SUBMITTER_NUMBER)
+                .withSubmitterNumber(JobSpecificationTemplate.getSubmitterNumberFor(
+                        dmatRecord.getUpdateCode() == UpdateCode.PUBLISHER
+                                ? JobSpecificationTemplate.JobSpecificationType.PUBLISHER
+                                : JobSpecificationTemplate.JobSpecificationType.RR))
                 .withFormat(config.getContent().getFormat())
                 .withCreationDate(Date.from(creationDate.atStartOfDay(timezone).plusHours(12).toInstant())))
                 .withDmatRecord(dmatRecord)
@@ -265,12 +291,14 @@ public class HarvestOperation {
                 .writerWithView(RecordView.Export.class).writeValueAsString(addiMetaData);
 
         // Fetch record to use for cloning or to update. Wrap in a collection since this is required by DAM
-        byte[] contentCollection = RecordFetcher.getRecordCollectionFor(recordServiceConnector, dmatRecord);
+        byte[] content = dmatRecord.getUpdateCode() == UpdateCode.PUBLISHER
+                ? TickleFetcher.getOnixProductFor(dmatRecord)
+                : RecordFetcher.getRecordCollectionFor(recordServiceConnector, dmatRecord);
 
         // Assembly addi object
         return new AddiRecord(
                 metaData.getBytes(StandardCharsets.UTF_8),
-                contentCollection);
+                content);
     }
 
     private void updateStatus(Integer caseId, Status status) throws UncheckedHarvesterException {

--- a/harvester/dmat/src/main/java/dk/dbc/dataio/harvester/dmat/JobSpecificationTemplate.java
+++ b/harvester/dmat/src/main/java/dk/dbc/dataio/harvester/dmat/JobSpecificationTemplate.java
@@ -5,17 +5,26 @@ import dk.dbc.dataio.harvester.types.HarvesterException;
 import dk.dbc.dataio.harvester.types.DMatHarvesterConfig;
 
 class JobSpecificationTemplate {
-    public static final int SUBMITTER_NUMBER = 190015;
+    public static final int SUBMITTER_NUMBER_RR = 190015;
+    public static final int SUBMITTER_NUMBER_PUBLIZON = 150015;
 
-    static JobSpecification create(DMatHarvesterConfig config) throws HarvesterException {
+    public enum JobSpecificationType { RR, PUBLISHER }
+
+    public static int getSubmitterNumberFor(JobSpecificationType type) {
+        return type == JobSpecificationType.PUBLISHER
+                ? SUBMITTER_NUMBER_PUBLIZON : SUBMITTER_NUMBER_RR;
+    }
+
+    static JobSpecification create(DMatHarvesterConfig config, JobSpecificationType type) throws HarvesterException {
         try {
             final DMatHarvesterConfig.Content configFields = config.getContent();
             return new JobSpecification()
                     .withPackaging("addi-xml")
                     .withFormat(configFields.getFormat())
                     .withCharset("utf8")
-                    .withDestination(configFields.getDestination())
-                    .withSubmitterId(SUBMITTER_NUMBER)
+                    .withDestination(type == JobSpecificationType.PUBLISHER
+                            ? configFields.getPublizon() : configFields.getDestination())
+                    .withSubmitterId(getSubmitterNumberFor(type))
                     .withMailForNotificationAboutVerification("placeholder")
                     .withMailForNotificationAboutProcessing("placeholder")
                     .withResultmailInitials("placeholder")

--- a/harvester/dmat/src/main/java/dk/dbc/dataio/harvester/dmat/TickleFetcher.java
+++ b/harvester/dmat/src/main/java/dk/dbc/dataio/harvester/dmat/TickleFetcher.java
@@ -1,0 +1,22 @@
+package dk.dbc.dataio.harvester.dmat;
+
+import dk.dbc.dmat.service.persistence.DMatRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+
+public class TickleFetcher {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TickleFetcher.class);
+
+    public static byte[] getOnixProductFor(DMatRecord dMatRecord) {
+        String id = dMatRecord.getIsbn();
+        LOGGER.info("Looking up original Publizon record with id {} in tickle-repo", id);
+
+        // Fetch onix record from tickle-repo
+        // Todo: Using tickle-repo-api, fetch the original incomming <Product/> block for
+        //       this record, identified by the isbn number.
+        //       Ref: https://dbcjira.atlassian.net/browse/DM2-217
+        return "<Product></Product>".getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/harvester/types/src/main/java/dk/dbc/dataio/harvester/types/DMatHarvesterConfig.java
+++ b/harvester/types/src/main/java/dk/dbc/dataio/harvester/types/DMatHarvesterConfig.java
@@ -50,7 +50,7 @@ public class DMatHarvesterConfig
 
         /**
          * Destination for harvested items that is to be exported to corepo (original
-         * Publizon Onix <Product/> blocks retrieved from tickle-repo)
+         * Publizon Onix Product blocks retrieved from tickle-repo)
          */
         private String publizon;
 

--- a/harvester/types/src/main/java/dk/dbc/dataio/harvester/types/DMatHarvesterConfig.java
+++ b/harvester/types/src/main/java/dk/dbc/dataio/harvester/types/DMatHarvesterConfig.java
@@ -44,9 +44,15 @@ public class DMatHarvesterConfig
         private String schedule;
 
         /**
-         * Destination for harvested items
+         * Destination for harvested items that is to be exported to RR
          */
         private String destination;
+
+        /**
+         * Destination for harvested items that is to be exported to corepo (original
+         * Publizon Onix <Product/> blocks retrieved from tickle-repo)
+         */
+        private String publizon;
 
         /**
          * Format of harvested items
@@ -95,6 +101,15 @@ public class DMatHarvesterConfig
 
         public Content withDestination(String destination) {
             this.destination = destination;
+            return this;
+        }
+
+        public String getPublizon() {
+            return publizon;
+        }
+
+        public Content withPublizon(String publizon) {
+            this.publizon = publizon;
             return this;
         }
 
@@ -156,6 +171,9 @@ public class DMatHarvesterConfig
             if (destination != null ? !destination.equals(content.destination) : content.destination != null) {
                 return false;
             }
+            if (publizon != null ? !publizon.equals(content.publizon) : content.publizon != null) {
+                return false;
+            }
             if (format != null ? !format.equals(content.format) : content.format != null) {
                 return false;
             }
@@ -168,6 +186,7 @@ public class DMatHarvesterConfig
             result = 31 * result + (description != null ? description.hashCode() : 0);
             result = 31 * result + (schedule != null ? schedule.hashCode() : 0);
             result = 31 * result + (destination != null ? destination.hashCode() : 0);
+            result = 31 * result + (publizon != null ? publizon.hashCode() : 0);
             result = 31 * result + (format != null ? format.hashCode() : 0);
             result = 31 * result + (enabled ? 1 : 0);
             result = 31 * result + (timeOfLastHarvest != null ? timeOfLastHarvest.hashCode() : 0);
@@ -181,6 +200,7 @@ public class DMatHarvesterConfig
                     ", description='" + description + '\'' +
                     ", schedule='" + schedule + '\'' +
                     ", destination='" + destination + '\'' +
+                    ", publizon='" + publizon + '\'' +
                     ", format='" + format + '\'' +
                     ", enabled=" + enabled +
                     ", timeOfLastHarvest=" + timeOfLastHarvest +

--- a/sink/dmat/pom.xml
+++ b/sink/dmat/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>dk.dbc</groupId>
       <artifactId>dmat-connector</artifactId>
-      <version>1.7-SNAPSHOT</version>
+      <version>1.9-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>dk.dbc</groupId>


### PR DESCRIPTION
(forlagsomtale) records, to ensure that the harvester does not explode
if such records where to be exported.

The harvester is not meant to be running in the prod environment until
the project is much further ahead, so potentially adding a pseudo record
to the staging corepo would be acceptable (but we should try to avoid it!)

Two stories describes the needed work to complete this flow
https://dbcjira.atlassian.net/browse/DM2-217
https://dbcjira.atlassian.net/browse/DM2-218