### PR TITLE
Add bibliographic id to the addi metadata when harvesting a dmat record

### DIFF
--- a/harvester/dmat/src/main/java/dk/dbc/dataio/harvester/dmat/HarvestOperation.java
+++ b/harvester/dmat/src/main/java/dk/dbc/dataio/harvester/dmat/HarvestOperation.java
@@ -264,7 +264,8 @@ public class HarvestOperation {
                                 ? JobSpecificationTemplate.JobSpecificationType.PUBLISHER
                                 : JobSpecificationTemplate.JobSpecificationType.RR))
                 .withFormat(config.getContent().getFormat())
-                .withCreationDate(Date.from(creationDate.atStartOfDay(timezone).plusHours(12).toInstant())))
+                .withCreationDate(Date.from(creationDate.atStartOfDay(timezone).plusHours(12).toInstant()))
+                .withBibliographicRecordId(dmatRecord.getIsbn()))
                 .withDmatRecord(dmatRecord)
                 .withDmatUrl(String.format(dmatDownloadUrl, dmatRecord.getId()));
         return metaData;


### PR DESCRIPTION
Bibliographic record is set to the isbn number for the record, since this
is the id that is used when pushing records into dmat from ticklerepo