### PR TITLE
Fix for retrying missing processing outcome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target
 # jenv
 .java-version
 **/.iml
+env-files

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 String docker_images_log_stash_tag = "docker_images_log"
 String workerNode = "devel11"
 Boolean DEPLOY_TO_STAGING_CANDIDATE=false
-//Byg!!
+//Byg!
 pipeline {
     agent { label workerNode }
     tools {

--- a/harvester/rr/src/main/java/dk/dbc/dataio/harvester/rr/HarvestOperation.java
+++ b/harvester/rr/src/main/java/dk/dbc/dataio/harvester/rr/HarvestOperation.java
@@ -139,7 +139,7 @@ public class HarvestOperation implements AutoCloseable {
 
             recordHarvestTaskQueue.commit();
 
-            LOGGER.info("Processed {} items from {} queue in {} ms",
+            if(itemsProcessed > 0) LOGGER.info("Processed {} items from {} queue in {} ms",
                     itemsProcessed, configContent.getConsumerId(), stopWatch.getElapsedTime());
 
             return itemsProcessed;

--- a/harvester/utils/rawrepo-connector/src/main/java/dk/dbc/dataio/harvester/utils/rawrepo/RawRepoConnector.java
+++ b/harvester/utils/rawrepo-connector/src/main/java/dk/dbc/dataio/harvester/utils/rawrepo/RawRepoConnector.java
@@ -44,7 +44,7 @@ public class RawRepoConnector {
             try {
                 return getRawRepoQueueDAO(connection).dequeue(consumerId);
             } finally {
-                LOGGER.info("RawRepo dequeue operation took {} milliseconds", stopWatch.getElapsedTime());
+                LOGGER.debug("RawRepo dequeue operation took {} milliseconds", stopWatch.getElapsedTime());
             }
         }
     }

--- a/job-store-service/distributed-objects/src/main/java/dk/dbc/dataio/jobstore/distributed/DependencyTracking.java
+++ b/job-store-service/distributed-objects/src/main/java/dk/dbc/dataio/jobstore/distributed/DependencyTracking.java
@@ -13,17 +13,15 @@ import java.sql.SQLException;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
 /**
  * Class for tracking chunk dependencies.
  */
-public class DependencyTracking implements DependencyTrackingRO, Serializable {
+public class DependencyTracking implements DependencyTrackingRO, Serializable, Comparable<DependencyTracking> {
     private static final long serialVersionUID = 1L;
     private static final ZoneId ZONE_ID_DK = ZoneId.of("Europe/Copenhagen");
 
@@ -79,11 +77,6 @@ public class DependencyTracking implements DependencyTrackingRO, Serializable {
     @Override
     public TrackingKey getKey() {
         return key;
-    }
-
-    public static Comparator<Map.Entry<TrackingKey, DependencyTracking>> comparePriorityAndKey() {
-        return Comparator.comparing((Map.Entry<TrackingKey, DependencyTracking> entry) -> entry.getValue().getPriority()).reversed()
-                .thenComparing((Map.Entry<TrackingKey, DependencyTracking> entry) -> entry.getValue().getKey());
     }
 
     @Override
@@ -231,6 +224,13 @@ public class DependencyTracking implements DependencyTrackingRO, Serializable {
                 ", status=" + status +
                 ", submitter=" + submitter +
                 '}';
+    }
+
+    @Override
+    public int compareTo(DependencyTracking o) {
+        int result = Integer.compare(o.priority, priority);
+        if(result != 0) return result;
+        return key.compareTo(o.getKey());
     }
 }
 

--- a/job-store-service/war/src/main/java/dk/dbc/dataio/jobstore/service/dependencytracking/DependencyTrackingService.java
+++ b/job-store-service/war/src/main/java/dk/dbc/dataio/jobstore/service/dependencytracking/DependencyTrackingService.java
@@ -216,6 +216,7 @@ public class DependencyTrackingService {
 
     public void reload() {
         dependencyTracker.loadAll(true);
+        recountSinkStatus(Set.of());
     }
 
     public void recountSinkStatus(Set<Integer> sinkIds) {
@@ -268,7 +269,7 @@ public class DependencyTrackingService {
         Predicate<TrackingKey, DependencyTracking> p;
         if(sinkId != null) p = e.get("sinkId").equal(sinkId).and(e.get("status").equal(status));
         else p = e.get("status").equal(status);
-        return Predicates.pagingPredicate(p, DependencyTracking.comparePriorityAndKey(), limit == null ? Integer.MAX_VALUE : limit);
+        return Predicates.pagingPredicate(p, limit == null ? Integer.MAX_VALUE : limit);
     }
 
     public List<TrackingKey> findChunksWaitingForMe(TrackingKey key, int sinkId) {

--- a/job-store-service/war/src/main/java/dk/dbc/dataio/jobstore/service/ejb/JobSchedulerTransactionsBean.java
+++ b/job-store-service/war/src/main/java/dk/dbc/dataio/jobstore/service/ejb/JobSchedulerTransactionsBean.java
@@ -209,7 +209,7 @@ public class JobSchedulerTransactionsBean {
             ChunkEntity.Key chunkKey = chunk.getKey();
             return jobStoreRepository.getChunk(Chunk.Type.PARTITIONED, chunkKey.getJobId(), chunkKey.getId());
         } catch (RuntimeException ex) {
-            LOGGER.error("Internal error Unable to get PARTITIONED items for {}", chunk.getKey());
+            LOGGER.warn("Internal error Unable to get PARTITIONED items for {}", chunk.getKey());
             throw ex;
         }
     }
@@ -217,10 +217,10 @@ public class JobSchedulerTransactionsBean {
     public Chunk getProcessedChunkFrom(TrackingKey dtKey) {
         try {
             ChunkEntity.Key chunkKey = new ChunkEntity.Key(dtKey.getChunkId(), dtKey.getJobId());
-
             return jobStoreRepository.getChunk(Chunk.Type.PROCESSED, chunkKey.getJobId(), chunkKey.getId());
         } catch (RuntimeException ex) {
-            LOGGER.error("Internal error Unable to get PROCESSED items for {}", dtKey, ex);
+            LOGGER.warn("Internal error Unable to get PROCESSED items for {}", dtKey, ex);
+            dependencyTrackingService.setStatus(dtKey, SCHEDULED_FOR_DELIVERY);
             throw ex;
         }
     }

--- a/job-store-service/war/src/main/java/dk/dbc/dataio/jobstore/service/ejb/PgJobStoreRepository.java
+++ b/job-store-service/war/src/main/java/dk/dbc/dataio/jobstore/service/ejb/PgJobStoreRepository.java
@@ -533,7 +533,7 @@ public class PgJobStoreRepository extends RepositoryBase {
             profiler.start("execute Query");
             final List<ItemEntity> itemEntities = new ItemListQuery(entityManager).execute(criteria);
             profiler.stop();
-            if (itemEntities.size() > 0) {
+            if (!itemEntities.isEmpty()) {
                 profiler.start("Loop itemEntities");
                 final Chunk chunk = new Chunk(jobId, chunkId, type);
                 int i = 0;

--- a/job-store-service/war/src/main/java/dk/dbc/dataio/jobstore/service/rs/AdminBean.java
+++ b/job-store-service/war/src/main/java/dk/dbc/dataio/jobstore/service/rs/AdminBean.java
@@ -64,8 +64,8 @@ import java.util.stream.Stream;
 
 import static dk.dbc.dataio.jobstore.distributed.ChunkSchedulingStatus.QUEUED_FOR_DELIVERY;
 import static dk.dbc.dataio.jobstore.distributed.ChunkSchedulingStatus.QUEUED_FOR_PROCESSING;
-import static dk.dbc.dataio.jobstore.distributed.ChunkSchedulingStatus.READY_FOR_DELIVERY;
-import static dk.dbc.dataio.jobstore.distributed.ChunkSchedulingStatus.READY_FOR_PROCESSING;
+import static dk.dbc.dataio.jobstore.distributed.ChunkSchedulingStatus.SCHEDULED_FOR_DELIVERY;
+import static dk.dbc.dataio.jobstore.distributed.ChunkSchedulingStatus.SCHEDULED_FOR_PROCESSING;
 
 @Stateless
 @Path("/")
@@ -238,10 +238,10 @@ public class AdminBean {
                 .map(SinkCacheEntity::getSink)
                 .map(Sink::getId)
                 .collect(Collectors.toSet());
-        int rowsUpdated = jobStoreRepository.resetStatus(jobIds, QUEUED_FOR_PROCESSING, READY_FOR_PROCESSING);
-        LOGGER.info("Reset dependency tracking states. Sets status = 1 for status = 2 for {} entities", rowsUpdated);
-        rowsUpdated = jobStoreRepository.resetStatus(jobIds, QUEUED_FOR_DELIVERY, READY_FOR_DELIVERY);
-        LOGGER.info("Reset dependency tracking states. Sets status = 4 for status = 5 for {} entities", rowsUpdated);
+        int rowsUpdated = jobStoreRepository.resetStatus(jobIds, QUEUED_FOR_PROCESSING, SCHEDULED_FOR_PROCESSING);
+        LOGGER.info("Reset dependency tracking states. Sets status QUEUED_FOR_PROCESSING -> SCHEDULED_FOR_PROCESSING for {} entities", rowsUpdated);
+        rowsUpdated = jobStoreRepository.resetStatus(jobIds, QUEUED_FOR_DELIVERY, SCHEDULED_FOR_DELIVERY);
+        LOGGER.info("Reset dependency tracking states. Sets status QUEUED_FOR_DELIVERY -> SCHEDULED_FOR_DELIVERY for {} entities", rowsUpdated);
         jobSchedulerBean.loadSinkStatusOnBootstrap(sinkId);
         return Response.ok().build();
     }


### PR DESCRIPTION
Af uransagelige grunde får vi fejl a.la Internal error Unable to get PROCESSED items for DependencyTrackingEntity.Key{jobId=30241701, chunkId=0} fordi at itemEntity.getProcessingOutcome() ikke har fået en værdi, men kører man det igen virker det fint...