### PR TITLE
wrap newPgJobStoreRepository in tests for JPA REQUIRES_NEW

### DIFF
--- a/job-store-service/war/src/test/java/dk/dbc/dataio/jobstore/service/AbstractJobStoreIT.java
+++ b/job-store-service/war/src/test/java/dk/dbc/dataio/jobstore/service/AbstractJobStoreIT.java
@@ -332,7 +332,7 @@ public class AbstractJobStoreIT extends JetTestSupport implements PostgresContai
             @Override
             public ChunkEntity createChunkEntity(long submitterId, int jobId, int chunkId, short maxChunkSize,
                                                  DataPartitioner dataPartitioner, KeyGenerator keyGenerator, String dataFileId) throws JobStoreException {
-                return handleRequiresNew(() -> createChunkEntity(submitterId, jobId, chunkId, maxChunkSize, dataPartitioner, keyGenerator, dataFileId));
+                return handleRequiresNew(() -> super.createChunkEntity(submitterId, jobId, chunkId, maxChunkSize, dataPartitioner, keyGenerator, dataFileId));
             }
         }
         .withEntityManager(entityManager);

--- a/job-store-service/war/src/test/java/dk/dbc/dataio/jobstore/service/ejb/PgJobStoreRepositoryIT.java
+++ b/job-store-service/war/src/test/java/dk/dbc/dataio/jobstore/service/ejb/PgJobStoreRepositoryIT.java
@@ -210,6 +210,7 @@ public class PgJobStoreRepositoryIT extends PgJobStoreRepositoryAbstractIT {
                 submitter, jobEntity.getId(), 0, (short) 10, dataPartitioner,
                 keyGenerator, dataFileId)
         );
+        entityManager.refresh(jobEntity); // pgJobStoreRepository runs stuff with TransactionAttributeType.REQUIRES_NEW
 
         assertThat("skipped", jobEntity.getSkipped(), is(73));
     }
@@ -398,6 +399,7 @@ public class PgJobStoreRepositoryIT extends PgJobStoreRepositoryAbstractIT {
 
         // And job1 is
         final JobEntity job1 = persistenceContext.run(() -> pgJobStoreRepository.getJobEntityById(jobId));
+        entityManager.refresh(job1);   // pgJobStoreRepository runs stuff with TransactionAttributeType.REQUIRES_NEW
 
         assertThat("Number of chunks", job1.getNumberOfChunks(), is(1));
         assertThat("Number of Items ", job1.getNumberOfItems(), is(1));


### PR DESCRIPTION
wrap newPgJobStoreRepository in AbstractJobStoreIT for simulation of TransactionAttributeType.REQUIRES_NEW