### PR TITLE
Upgrade to JUnit 6 (6.0.3)

### DIFF
--- a/jse-app/pom.xml
+++ b/jse-app/pom.xml
@@ -43,7 +43,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson-annotations.version}</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,18 @@
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit5.version}</version>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- JUnit 6 unified all modules (jupiter, vintage, platform) onto the same version line.
+             maven-surefire-plugin bundles its own junit-platform-launcher from the 1.x stream,
+             which is incompatible with the 6.x engines. Declaring the launcher here at ${junit.version}
+             places a 6.x launcher on the test classpath before surefire's bundled one, aligning all
+             platform jars and preventing the "OutputDirectoryCreator not available" error at runtime. -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -107,6 +118,11 @@
                 <groupId>com.beust</groupId>
                 <artifactId>jcommander</artifactId>
                 <version>1.58</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson-annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
@@ -1225,12 +1241,12 @@
                     <dependency>
                         <groupId>org.junit.jupiter</groupId>
                         <artifactId>junit-jupiter-engine</artifactId>
-                        <version>${junit5.version}</version>
+                        <version>${junit.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>org.junit.vintage</groupId>
                         <artifactId>junit-vintage-engine</artifactId>
-                        <version>${junit5.version}</version>
+                        <version>${junit.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
The parent super-pom has moved to junit.version=6.0.3. Switch the three ${junit5.version} references in the surefire plugin and the global junit-vintage-engine dependency to ${junit.version}.

JUnit 6 unified all platform modules onto the same version line, so the 6.x engine jars clash with the 1.x junit-platform-launcher bundled by maven-surefire-plugin. Adding junit-platform-launcher at ${junit.version} as a test dependency places the aligned 6.x launcher on the classpath first.

Also fix jackson-annotations version in jse-app/pom.xml: Jackson 2.20.0 dropped the patch segment from that artifact (it is now versioned 2.20, not 2.20.0), so use ${jackson-annotations.version} instead of ${jackson.version} to avoid resolving a non-existent artifact.