### PR TITLE
Move groupId and validateOnly to env configuration in rawrepo-update-v3 sink

### DIFF
--- a/commons/types/src/main/java/dk/dbc/dataio/commons/types/OpenUpdateSinkConfig.java
+++ b/commons/types/src/main/java/dk/dbc/dataio/commons/types/OpenUpdateSinkConfig.java
@@ -1,19 +1,26 @@
 package dk.dbc.dataio.commons.types;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import dk.dbc.invariant.InvariantUtil;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class OpenUpdateSinkConfig implements SinkConfig, Serializable {
 
     private static final long serialVersionUID = 3950981967853410646L;
+
     private String userId;
     private String password;
+    @JsonIgnore // This is set manually by the environment.
+    private String groupId;
+    @JsonIgnore // This is set manually by the environment.
+    private Boolean validateOnly;
     private String endpoint;
     private List<String> availableQueueProviders;
     private Set<String> ignoredValidationErrors;
@@ -38,6 +45,24 @@ public class OpenUpdateSinkConfig implements SinkConfig, Serializable {
 
     public String getEndpoint() {
         return endpoint;
+    }
+
+    public OpenUpdateSinkConfig withGroupId(String groupId) {
+        this.groupId = groupId;
+        return this;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public OpenUpdateSinkConfig withValidateOnly(Boolean validateOnly) {
+        this.validateOnly = validateOnly;
+        return this;
+    }
+
+    public Boolean isValidateOnly() {
+        return validateOnly;
     }
 
     public OpenUpdateSinkConfig withEndpoint(String endpoint) {
@@ -65,44 +90,30 @@ public class OpenUpdateSinkConfig implements SinkConfig, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         OpenUpdateSinkConfig that = (OpenUpdateSinkConfig) o;
-
-        if (userId != null ? !userId.equals(that.userId) : that.userId != null) {
-            return false;
-        }
-        if (password != null ? !password.equals(that.password) : that.password != null) {
-            return false;
-        }
-        if (endpoint != null ? !endpoint.equals(that.endpoint) : that.endpoint != null) {
-            return false;
-        }
-        if (availableQueueProviders != null ? !availableQueueProviders.equals(that.availableQueueProviders) : that.availableQueueProviders != null) {
-            return false;
-        }
-        return ignoredValidationErrors != null ? ignoredValidationErrors.equals(that.ignoredValidationErrors) : that.ignoredValidationErrors == null;
+        return Objects.equals(userId, that.userId)
+                && Objects.equals(password, that.password)
+                && Objects.equals(groupId, that.groupId)
+                && Objects.equals(validateOnly, that.validateOnly)
+                && Objects.equals(endpoint, that.endpoint)
+                && Objects.equals(availableQueueProviders, that.availableQueueProviders)
+                && Objects.equals(ignoredValidationErrors, that.ignoredValidationErrors);
     }
 
     @Override
     public int hashCode() {
-        int result = userId != null ? userId.hashCode() : 0;
-        result = 31 * result + (password != null ? password.hashCode() : 0);
-        result = 31 * result + (endpoint != null ? endpoint.hashCode() : 0);
-        result = 31 * result + (availableQueueProviders != null ? availableQueueProviders.hashCode() : 0);
-        result = 31 * result + (ignoredValidationErrors != null ? ignoredValidationErrors.hashCode() : 0);
-        return result;
+        return Objects.hash(userId, password, groupId, validateOnly, endpoint, availableQueueProviders, ignoredValidationErrors);
     }
 
     @Override
     public String toString() {
         return "OpenUpdateSinkConfig{" +
                 "userId='" + userId + '\'' +
+                ", groupId='" + groupId + '\'' +
+                ", validateOnly=" + validateOnly +
                 ", endpoint='" + endpoint + '\'' +
                 ", availableQueueProviders=" + availableQueueProviders +
                 ", ignoredValidationErrors=" + ignoredValidationErrors +

--- a/commons/types/src/test/java/dk/dbc/dataio/commons/types/OpenUpdateSinkConfigTest.java
+++ b/commons/types/src/test/java/dk/dbc/dataio/commons/types/OpenUpdateSinkConfigTest.java
@@ -4,13 +4,14 @@ import dk.dbc.commons.jsonb.JSONBContext;
 import dk.dbc.commons.jsonb.JSONBException;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import static dk.dbc.commons.testutil.Assert.assertThat;
 import static dk.dbc.commons.testutil.Assert.isThrowing;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
@@ -21,10 +22,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
  * unitOfWork_stateUnderTest_expectedBehavior
  */
 public class OpenUpdateSinkConfigTest {
-    private static final String USER_ID = "userId";
-    private static final String PASSWORD = "password";
-    private static final String ENDPOINT = "endpoint";
-    private static final List<String> AVAILABLE_QUEUE_PROVIDERS = Arrays.asList("qp1", "qp2");
 
     @Test
     public void withUserId_userIdArgIsNull_throws() {
@@ -70,13 +67,32 @@ public class OpenUpdateSinkConfigTest {
     @Test
     public void marshalling() throws JSONBException {
         JSONBContext jsonbContext = new JSONBContext();
-        OpenUpdateSinkConfig openUpdateSinkConfig = new OpenUpdateSinkConfig();
-        OpenUpdateSinkConfig unmarshalled = jsonbContext.unmarshall(jsonbContext.marshall(openUpdateSinkConfig), OpenUpdateSinkConfig.class);
+        OpenUpdateSinkConfig openUpdateSinkConfig = config();
+        OpenUpdateSinkConfig unmarshalled = jsonbContext.unmarshall(
+                jsonbContext.marshall(openUpdateSinkConfig),
+                OpenUpdateSinkConfig.class);
         assertThat(unmarshalled, is(openUpdateSinkConfig));
     }
 
-    public static OpenUpdateSinkConfig newOpenUpdateSinkConfigInstance() {
-        return new OpenUpdateSinkConfig().withUserId(USER_ID).withPassword(PASSWORD).withEndpoint(ENDPOINT).withAvailableQueueProviders(AVAILABLE_QUEUE_PROVIDERS);
+    @Test
+    public void marshalling_withIgnoredFields() throws JSONBException {
+        JSONBContext jsonbContext = new JSONBContext();
+        OpenUpdateSinkConfig openUpdateSinkConfig = config()
+                .withGroupId("group")
+                .withValidateOnly(false);
+        OpenUpdateSinkConfig unmarshalled = jsonbContext.unmarshall(
+                jsonbContext.marshall(openUpdateSinkConfig),
+                OpenUpdateSinkConfig.class);
+        assertThat("unmarshalled", unmarshalled, is(not(openUpdateSinkConfig)));
+        assertThat("unmarshalled.getGroupId", unmarshalled.getGroupId(), is(nullValue()));
+        assertThat("unmarshalled.isValidateOnly", unmarshalled.isValidateOnly(), is(nullValue()));
     }
 
+    public static OpenUpdateSinkConfig config() {
+        return new OpenUpdateSinkConfig()
+                .withUserId("user")
+                .withPassword("secret")
+                .withEndpoint("http://update-service")
+                .withAvailableQueueProviders(List.of("qp1", "qp2"));
+    }
 }

--- a/commons/types/src/test/java/dk/dbc/dataio/commons/types/SinkContentTest.java
+++ b/commons/types/src/test/java/dk/dbc/dataio/commons/types/SinkContentTest.java
@@ -19,7 +19,7 @@ public class SinkContentTest {
     private static final String QUEUE = "queue";
     private static final String DESCRIPTION = "description";
     private static final SinkContent.SinkType SINK_TYPE = SinkContent.SinkType.OPENUPDATE;
-    private static final SinkConfig SINK_CONFIG = OpenUpdateSinkConfigTest.newOpenUpdateSinkConfigInstance();
+    private static final SinkConfig SINK_CONFIG = OpenUpdateSinkConfigTest.config();
     private static final SinkContent.SequenceAnalysisOption SEQUENCE_ANALYSIS_OPTION = SinkContent.SequenceAnalysisOption.ALL;
 
     public static SinkContent newSinkContentInstance() {

--- a/commons/utils/rawrepo-update-v3-connector/src/main/java/dk/dbc/dataio/sink/rawrepo/update/v3/connector/UpdateRequest.java
+++ b/commons/utils/rawrepo-update-v3-connector/src/main/java/dk/dbc/dataio/sink/rawrepo/update/v3/connector/UpdateRequest.java
@@ -10,9 +10,6 @@ public class UpdateRequest {
     // body sent to the update service (type travels as a URL path segment, not a body field)
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String type = "dbc";
-    // WRITE_ONLY: populated from incoming JSON and used as the groupId in Authentication,
-    // but excluded from the body sent to the update service
-    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String submitter;
     private String templateName;
     private String trackingId;

--- a/commons/utils/rawrepo-update-v3-connector/src/main/java/dk/dbc/dataio/sink/rawrepo/update/v3/connector/UpdateRequest.java
+++ b/commons/utils/rawrepo-update-v3-connector/src/main/java/dk/dbc/dataio/sink/rawrepo/update/v3/connector/UpdateRequest.java
@@ -1,5 +1,6 @@
 package dk.dbc.dataio.sink.rawrepo.update.v3.connector;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -10,7 +11,8 @@ public class UpdateRequest {
     // body sent to the update service (type travels as a URL path segment, not a body field)
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String type = "dbc";
-    private String submitter;
+    @JsonAlias("submitter")
+    private String overrideSubmitter;
     private String templateName;
     private String trackingId;
     private Authentication authentication;
@@ -25,12 +27,12 @@ public class UpdateRequest {
         this.type = type;
     }
 
-    public String getSubmitter() {
-        return submitter;
+    public String getOverrideSubmitter() {
+        return overrideSubmitter;
     }
 
-    public void setSubmitter(String submitter) {
-        this.submitter = submitter;
+    public void setOverrideSubmitter(String overrideSubmitter) {
+        this.overrideSubmitter = overrideSubmitter;
     }
 
     public String getTemplateName() {

--- a/commons/utils/rawrepo-update-v3-connector/src/test/java/dk/dbc/dataio/sink/rawrepo/update/v3/connector/UpdateServiceConnectorTest.java
+++ b/commons/utils/rawrepo-update-v3-connector/src/test/java/dk/dbc/dataio/sink/rawrepo/update/v3/connector/UpdateServiceConnectorTest.java
@@ -87,7 +87,7 @@ class UpdateServiceConnectorTest {
 
         UpdateRequest request = new UpdateRequest();
         request.setType(type);
-        request.setSubmitter("870970");
+        request.setOverrideSubmitter("870970");
         request.setAuthentication(auth);
         request.setTemplateName(templateName);
         request.setContent(content);

--- a/sink/rawrepo-update-v3/src/main/java/dk/dbc/dataio/sink/rawrepo/update/v3/ChunkItemProcessor.java
+++ b/sink/rawrepo-update-v3/src/main/java/dk/dbc/dataio/sink/rawrepo/update/v3/ChunkItemProcessor.java
@@ -89,7 +89,7 @@ public class ChunkItemProcessor {
                     ? connector.validate(record)
                     : connector.update(record);
             Metric.update_service_requests.timer(
-                    new Tag("submitter", Objects.requireNonNullElse(record.getSubmitter(), "unknown")),
+                    new Tag("submitter", Objects.requireNonNullElse(record.getOverrideSubmitter(), "unknown")),
                     new Tag("template", record.getTemplateName()))
                     .update(Duration.ofMillis(System.currentTimeMillis() - startTime));
 

--- a/sink/rawrepo-update-v3/src/main/java/dk/dbc/dataio/sink/rawrepo/update/v3/ChunkItemProcessor.java
+++ b/sink/rawrepo-update-v3/src/main/java/dk/dbc/dataio/sink/rawrepo/update/v3/ChunkItemProcessor.java
@@ -21,6 +21,7 @@ import java.io.ByteArrayInputStream;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class ChunkItemProcessor {
     private static final Logger LOGGER = LoggerFactory.getLogger(ChunkItemProcessor.class);
@@ -29,15 +30,11 @@ public class ChunkItemProcessor {
     private final UpdateServiceConnector connector;
     private final OpenUpdateSinkConfig config;
     private final ValidationMessageInterpreter validationMessageInterpreter;
-    private final boolean validateOnly;
 
-    public ChunkItemProcessor(UpdateServiceConnector connector,
-                              OpenUpdateSinkConfig config,
-                              boolean validateOnly) {
+    public ChunkItemProcessor(UpdateServiceConnector connector, OpenUpdateSinkConfig config) {
         this.connector = connector;
         this.config = config;
         this.validationMessageInterpreter = new ValidationMessageInterpreter(config.getIgnoredValidationErrors());
-        this.validateOnly = validateOnly;
     }
 
     public ChunkItem process(ChunkItem chunkItem) {
@@ -79,7 +76,7 @@ public class ChunkItemProcessor {
     private void setAuthentication(UpdateRequest record) {
         Authentication auth = new Authentication();
         auth.setUserId(config.getUserId());
-        auth.setGroupId(record.getSubmitter());
+        auth.setGroupId(config.getGroupId());
         auth.setPassword(config.getPassword());
         record.setAuthentication(auth);
     }
@@ -88,11 +85,11 @@ public class ChunkItemProcessor {
                                    List<Diagnostic> diagnostics, int index, int total) {
         try {
             long startTime = System.currentTimeMillis();
-            UpdateResponse response = validateOnly
+            UpdateResponse response = config.isValidateOnly()
                     ? connector.validate(record)
                     : connector.update(record);
             Metric.update_service_requests.timer(
-                    new Tag("submitter", record.getSubmitter()),
+                    new Tag("submitter", Objects.requireNonNullElse(record.getSubmitter(), "unknown")),
                     new Tag("template", record.getTemplateName()))
                     .update(Duration.ofMillis(System.currentTimeMillis() - startTime));
 

--- a/sink/rawrepo-update-v3/src/main/java/dk/dbc/dataio/sink/rawrepo/update/v3/ConfigRefresher.java
+++ b/sink/rawrepo-update-v3/src/main/java/dk/dbc/dataio/sink/rawrepo/update/v3/ConfigRefresher.java
@@ -12,9 +12,10 @@ import org.slf4j.LoggerFactory;
 public class ConfigRefresher {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfigRefresher.class);
 
-    boolean validateOnly = SinkConfig.UPDATE_VALIDATE_ONLY_FLAG.asBoolean();
-
+    private final boolean validateOnly = SinkConfig.UPDATE_VALIDATE_ONLY_FLAG.asBoolean();
+    private final String groupId = SinkConfig.GROUP_ID.asString();
     private final FlowStoreServiceConnector flowStoreServiceConnector;
+
     private long highestVersionSeen = 0;
     private OpenUpdateSinkConfig config;
 
@@ -33,7 +34,9 @@ public class ConfigRefresher {
             long sinkVersion = JMSHeader.sinkVersion.getHeader(consumedMessage, Long.class);
             if (sinkVersion > highestVersionSeen) {
                 Sink sink = flowStoreServiceConnector.getSink(sinkId);
-                config = (OpenUpdateSinkConfig) sink.getContent().getSinkConfig();
+                config = ((OpenUpdateSinkConfig) sink.getContent().getSinkConfig())
+                        .withGroupId(groupId)
+                        .withValidateOnly(validateOnly);
                 if (!validateOnly) {
                     // ignoredValidationErrors are only meaningful during validation runs,
                     // strip them in normal update mode so the full error set is reported.

--- a/sink/rawrepo-update-v3/src/main/java/dk/dbc/dataio/sink/rawrepo/update/v3/SinkConfig.java
+++ b/sink/rawrepo-update-v3/src/main/java/dk/dbc/dataio/sink/rawrepo/update/v3/SinkConfig.java
@@ -6,6 +6,7 @@ public enum SinkConfig implements EnvConfig {
     QUEUE,
     MESSAGE_FILTER,
     FLOWSTORE_URL,
+    GROUP_ID,
     UPDATE_VALIDATE_ONLY_FLAG("false");
 
     private final String defaultValue;

--- a/sink/rawrepo-update-v3/src/main/java/dk/dbc/dataio/sink/rawrepo/update/v3/UpdateMessageConsumer.java
+++ b/sink/rawrepo-update-v3/src/main/java/dk/dbc/dataio/sink/rawrepo/update/v3/UpdateMessageConsumer.java
@@ -40,8 +40,7 @@ public class UpdateMessageConsumer extends MessageConsumerAdapter {
         try {
             OpenUpdateSinkConfig sinkConfig = getConfig(consumedMessage);
             Chunk outcome = new Chunk(chunk.getJobId(), chunk.getChunkId(), Chunk.Type.DELIVERED);
-            ChunkItemProcessor chunkItemProcessor = new ChunkItemProcessor(
-                    connector, sinkConfig, configRefresher.validateOnly);
+            ChunkItemProcessor chunkItemProcessor = new ChunkItemProcessor(connector, sinkConfig);
             try {
                 for (ChunkItem chunkItem : chunk) {
                     DBCTrackedLogContext.setTrackingId(chunkItem.getTrackingId());

--- a/sink/rawrepo-update-v3/src/test/java/dk/dbc/dataio/sink/rawrepo/update/v3/ChunkItemProcessorTest.java
+++ b/sink/rawrepo-update-v3/src/test/java/dk/dbc/dataio/sink/rawrepo/update/v3/ChunkItemProcessorTest.java
@@ -26,14 +26,17 @@ import static org.mockito.Mockito.when;
 
 class ChunkItemProcessorTest {
     private final UpdateServiceConnector connector = mock(UpdateServiceConnector.class);
-    private final OpenUpdateSinkConfig config = new OpenUpdateSinkConfig()
-            .withEndpoint("http://update-service")
-            .withUserId("user")
-            .withPassword("secret");
+
+    private OpenUpdateSinkConfig config() {
+        return new OpenUpdateSinkConfig()
+                .withEndpoint("http://update-service")
+                .withUserId("user")
+                .withPassword("secret")
+                .withGroupId("010100")
+                .withValidateOnly(false);
+    }
 
     // Builds ChunkItem data as raw JSON strings (matching real job-processor output).
-    // submitter is WRITE_ONLY on UpdateRequest so it must be in the JSON source, not
-    // constructed via setSubmitter() before serialisation — WRITE_ONLY excludes it on write.
     private ChunkItem chunkItemWithRequests(String... jsonElements) {
         String json = "[" + String.join(",", jsonElements) + "]";
         return ChunkItem.successfulChunkItem()
@@ -73,7 +76,7 @@ class ChunkItemProcessorTest {
         when(connector.update(any())).thenReturn(okResponse());
 
         // no "type" key → UpdateRequest.type stays at its default "dbc"
-        ChunkItem result = new ChunkItemProcessor(connector, config, false)
+        ChunkItem result = new ChunkItemProcessor(connector, config())
                 .process(chunkItemWithRequests("{\"submitter\":\"870970\",\"templateName\":\"bog\",\"content\":{}}"));
 
         verify(connector).update(any(UpdateRequest.class));
@@ -84,7 +87,7 @@ class ChunkItemProcessorTest {
     void process_singleRequestWithType_callsConnectorWithThatType() throws Exception {
         when(connector.update(any())).thenReturn(okResponse());
 
-        new ChunkItemProcessor(connector, config, false)
+        new ChunkItemProcessor(connector, config())
                 .process(chunkItemWithRequests(req("dbc")));
 
         verify(connector).update(any(UpdateRequest.class));
@@ -98,12 +101,12 @@ class ChunkItemProcessorTest {
             return okResponse();
         });
 
-        new ChunkItemProcessor(connector, config, false)
+        new ChunkItemProcessor(connector, config())
                 .process(chunkItemWithRequests(req()));
 
         assertThat(captured[0].getAuthentication(), notNullValue());
         assertThat(captured[0].getAuthentication().getUserId(), is("user"));
-        assertThat(captured[0].getAuthentication().getGroupId(), is("870970"));
+        assertThat(captured[0].getAuthentication().getGroupId(), is("010100"));
         assertThat(captured[0].getAuthentication().getPassword(), is("secret"));
     }
 
@@ -111,7 +114,7 @@ class ChunkItemProcessorTest {
     void process_validateOnly_callsValidate() throws Exception {
         when(connector.validate(any())).thenReturn(okResponse());
 
-        new ChunkItemProcessor(connector, config, true)
+        new ChunkItemProcessor(connector, config().withValidateOnly(true))
                 .process(chunkItemWithRequests(req()));
 
         verify(connector).validate(any(UpdateRequest.class));
@@ -121,7 +124,7 @@ class ChunkItemProcessorTest {
     void process_okResponse_returnsSuccessfulChunkItem() throws Exception {
         when(connector.update(any())).thenReturn(okResponse());
 
-        ChunkItem result = new ChunkItemProcessor(connector, config, false)
+        ChunkItem result = new ChunkItemProcessor(connector, config())
                 .process(chunkItemWithRequests(req()));
 
         assertThat(result.getStatus(), is(ChunkItem.Status.SUCCESS));
@@ -132,12 +135,12 @@ class ChunkItemProcessorTest {
     void process_errorResponse_returnsFailedChunkItemWithDiagnostics() throws Exception {
         when(connector.update(any())).thenReturn(errorResponse("Felt 245 delfelt a mangler"));
 
-        ChunkItem result = new ChunkItemProcessor(connector, config, false)
+        ChunkItem result = new ChunkItemProcessor(connector, config())
                 .process(chunkItemWithRequests(req()));
 
         assertThat(result.getStatus(), is(ChunkItem.Status.FAILURE));
         assertThat(result.getDiagnostics().size(), is(1));
-        assertThat(result.getDiagnostics().get(0).getMessage(), is("Felt 245 delfelt a mangler"));
+        assertThat(result.getDiagnostics().getFirst().getMessage(), is("Felt 245 delfelt a mangler"));
         assertThat(new String(result.getData(), StandardCharsets.UTF_8).contains("e01 00"), is(true));
     }
 
@@ -145,7 +148,7 @@ class ChunkItemProcessorTest {
     void process_multipleRequests_allAttempted() throws Exception {
         when(connector.update(any())).thenReturn(okResponse());
 
-        ChunkItem result = new ChunkItemProcessor(connector, config, false)
+        ChunkItem result = new ChunkItemProcessor(connector, config())
                 .process(chunkItemWithRequests(req(), req("dbc")));
 
         verify(connector, times(2)).update(any());
@@ -158,7 +161,7 @@ class ChunkItemProcessorTest {
                 .thenReturn(okResponse())
                 .thenReturn(errorResponse("error in second"));
 
-        ChunkItem result = new ChunkItemProcessor(connector, config, false)
+        ChunkItem result = new ChunkItemProcessor(connector, config())
                 .process(chunkItemWithRequests(req(), req()));
 
         assertThat(result.getStatus(), is(ChunkItem.Status.FAILURE));
@@ -178,7 +181,7 @@ class ChunkItemProcessorTest {
         response.setErrors(List.of(vm));
         when(connector.update(any())).thenReturn(response);
 
-        ChunkItem result = new ChunkItemProcessor(connector, config, false)
+        ChunkItem result = new ChunkItemProcessor(connector, config())
                 .process(chunkItemWithRequests(req()));
 
         assertThat(result.getStatus(), is(ChunkItem.Status.SUCCESS));
@@ -189,12 +192,12 @@ class ChunkItemProcessorTest {
     void process_connectorException_accumulatedAsFatalDiagnostic() throws Exception {
         when(connector.update(any())).thenThrow(new UpdateServiceConnectorException("auth failed"));
 
-        ChunkItem result = new ChunkItemProcessor(connector, config, false)
+        ChunkItem result = new ChunkItemProcessor(connector, config())
                 .process(chunkItemWithRequests(req()));
 
         assertThat(result.getStatus(), is(ChunkItem.Status.FAILURE));
         assertThat(result.getDiagnostics().size(), is(1));
-        assertThat(result.getDiagnostics().get(0).getLevel(), is(Diagnostic.Level.FATAL));
+        assertThat(result.getDiagnostics().getFirst().getLevel(), is(Diagnostic.Level.FATAL));
     }
 
     @Test
@@ -205,9 +208,9 @@ class ChunkItemProcessorTest {
                 .withType(ChunkItem.Type.STRING)
                 .withEncoding(StandardCharsets.UTF_8);
 
-        ChunkItem result = new ChunkItemProcessor(connector, config, false).process(item);
+        ChunkItem result = new ChunkItemProcessor(connector, config()).process(item);
 
         assertThat(result.getStatus(), is(ChunkItem.Status.FAILURE));
-        assertThat(result.getDiagnostics().get(0).getLevel(), is(Diagnostic.Level.FATAL));
+        assertThat(result.getDiagnostics().getFirst().getLevel(), is(Diagnostic.Level.FATAL));
     }
 }


### PR DESCRIPTION
Previously groupId was sourced per-record from the submitter field; validateOnly was a constructor parameter on ChunkItemProcessor. Both are now read from environment variables (GROUP_ID, UPDATE_VALIDATE_ONLY_FLAG) and injected into OpenUpdateSinkConfig by ConfigRefresher, giving the sink a single consistent authentication identity across all records.

Also null-safes the submitter metrics tag, falling back to "unknown" when submitter is absent from the incoming JSON.