### PR TITLE
Fail items that do not return strings

### DIFF
--- a/job-processor-graaljs/src/main/java/dk/dbc/dataio/jobprocessorgjs/javascript/GraalJsScript.java
+++ b/job-processor-graaljs/src/main/java/dk/dbc/dataio/jobprocessorgjs/javascript/GraalJsScript.java
@@ -60,7 +60,15 @@ public class GraalJsScript implements AutoCloseable {
                     "Invocation method '" + invocationMethod + "' not found in script '" + scriptId + "'");
         }
         Value result = function.execute(args);
-        return result.isString() ? result.asString() : null;
+        // The record-processing contract requires the invocation method to return the
+        // transformed record as a string (an empty string signals "ignore"). Anything else
+        // is a script bug; fail the item loudly rather than silently discarding it.
+        if (!result.isString()) {
+            throw new IllegalStateException(String.format(
+                    "Invocation method '%s' in script '%s' returned a non-string value; expected a string but got: %s",
+                    invocationMethod, scriptId, result.isNull() ? "null or undefined" : result));
+        }
+        return result.asString();
     }
 
     // eval is intentional: the expression is either the JMS additionalArgs JSON (non-ADDI items)

--- a/job-processor-graaljs/src/main/java/dk/dbc/dataio/jobprocessorgjs/service/ChunkItemProcessor.java
+++ b/job-processor-graaljs/src/main/java/dk/dbc/dataio/jobprocessorgjs/service/ChunkItemProcessor.java
@@ -67,7 +67,7 @@ public class ChunkItemProcessor {
 
             String scriptResult = script.invoke(new Object[]{itemData, supplement});
 
-            if (scriptResult == null || scriptResult.isEmpty()) {
+            if (scriptResult.isEmpty()) {
                 return ChunkItem.ignoredChunkItem()
                         .withId(chunkItem.getId())
                         .withData("Ignored by job-processor since returned data was empty")

--- a/job-processor-graaljs/src/test/java/dk/dbc/dataio/jobprocessorgjs/service/ChunkItemProcessorTest.java
+++ b/job-processor-graaljs/src/test/java/dk/dbc/dataio/jobprocessorgjs/service/ChunkItemProcessorTest.java
@@ -76,13 +76,13 @@ class ChunkItemProcessorTest {
     }
 
     @Test
-    void process_successItem_scriptReturnsNull_returnsIgnoredItem() throws IOException {
+    void process_successItem_scriptReturnsNonString_returnsFailedItem() throws IOException {
         ChunkItem input = new ChunkItemBuilder()
                 .setId(1).setData("hello").setTrackingId("t1")
                 .build();
         try (GraalJsScript script = scriptWith("export function process(d, s) { return null; }")) {
             ChunkItem result = processor(script).process(input);
-            assertThat(result.getStatus(), is(ChunkItem.Status.IGNORE));
+            assertThat(result.getStatus(), is(ChunkItem.Status.FAILURE));
         }
     }
 


### PR DESCRIPTION
Return type of scripts should be strings (empty string for ignored records). Make sure to mark item failed if it returns something else instead of swallowing it with a ignored record.