### PR TITLE
Update artemis-admin-client to version 21.2.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
             <dependency>
                 <groupId>dk.dbc</groupId>
                 <artifactId>artemis-admin-client</artifactId>
-                <version>2.0-SNAPSHOT</version>
+                <version>21.2.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>dk.dbc</groupId>


### PR DESCRIPTION
To get a version that is compatible with dbc-commons-httpclient library used by the rest of the dataio system, thus fixing the broken stale connection checker.